### PR TITLE
Add codex_setup script

### DIFF
--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exit early if setup already ran
+if [[ "${DEV_ENV_BUILT:-}" == "1" ]]; then
+  echo "Development environment already built"
+  exit 0
+fi
+
+# Load nvm if available
+export NVM_DIR="$HOME/.nvm"
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+else
+  # TODO: install nvm if not present
+  echo "nvm not found"
+fi
+
+# Install Node version from .nvmrc
+NODE_VERSION="$(cat .nvmrc)"
+nvm install "$NODE_VERSION"
+nvm use "$NODE_VERSION"
+
+# Install Yarn matching packageManager field
+YARN_VERSION="$(grep -oE '"packageManager":\s*"yarn@([^"]+)"' package.json | cut -d@ -f2 | tr -d '"')"
+npm install -g "yarn@${YARN_VERSION}"
+
+# Install JS dependencies
+yarn install --frozen-lockfile
+
+# Persist environment configuration
+{
+  echo 'export NVM_DIR="$HOME/.nvm"'
+  echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"'
+  echo 'export DEV_ENV_BUILT=1'
+} >> "$HOME/.profile"
+
+export DEV_ENV_BUILT=1
+
+echo "Dev environment setup complete"


### PR DESCRIPTION
## Summary
- add `codex_setup.sh` for installing Node and yarn from manifest

## Testing
- `bash ./codex_setup.sh`
- `yarn lint`
- `yarn test --runTestsByPath packages/react/src/__tests__/onlyChild-test.js`


------
https://chatgpt.com/codex/tasks/task_i_68418b5f18c48327b5676a169e9ba65b